### PR TITLE
Build fixes.

### DIFF
--- a/com.ibm.wala.cast.java.polyglot/build.xml
+++ b/com.ibm.wala.cast.java.polyglot/build.xml
@@ -17,7 +17,7 @@
 	<!-- This property has been updated to correspond to the paths used by the latest Java update
 	on Mac OS X 10.6 (Java version 1.6.0_22).  If you are not using this version of Mac OS X or Java,
 	try changing the value of the property to "${java.home}/../../../Classes" -->
-    <condition property="dir_bootclasspath" value="${java.home}/../Classes">
+<!--    <condition property="dir_bootclasspath" value="${java.home}/../Classes">
             <os family="mac"/>
     </condition>
     <property name="dir_bootclasspath" value="${java.home}/lib"/>
@@ -30,7 +30,7 @@
 	<property name="bootclasspath" refid="path_bootclasspath"/>
 	<property name="bundleJavacSource" value="${javacSource}"/>
 	<property name="bundleJavacTarget" value="${javacTarget}"/>
-	<property name="bundleBootClasspath" value="${bootclasspath}"/>
+	<property name="bundleBootClasspath" value="${bootclasspath}"/> -->
 
      <target name="PolyglotPresent" depends="init">
         <available file="${plugin.destination}/lib/polyglot.jar" property="polyglot.present"/>

--- a/com.ibm.wala.cast.java.polyglot/pom.xml
+++ b/com.ibm.wala.cast.java.polyglot/pom.xml
@@ -30,6 +30,15 @@
 						</goals>
 					</execution>
 				</executions>
+              <dependencies>
+                <dependency>
+                  <groupId>com.sun</groupId>
+                  <artifactId>tools</artifactId>
+                  <version>1.7</version>
+                  <scope>system</scope>
+                  <systemPath>${java.home}/../lib/tools.jar</systemPath>
+                </dependency>
+              </dependencies>
 			</plugin>
 		</plugins>
 	</build>

--- a/com.ibm.wala.cast.js.rhino/META-INF/MANIFEST.MF
+++ b/com.ibm.wala.cast.js.rhino/META-INF/MANIFEST.MF
@@ -35,5 +35,5 @@ Export-Package: com.ibm.wala.cast.js.translator,
  org.mozilla.javascript.xml,
  org.mozilla.javascript.xml.impl.xmlbeans,
  org.mozilla.javascript.xmlimpl
-Bundle-ClassPath: lib/js.jar,
+Bundle-ClassPath: lib/rhino-1.7R3.jar,
  .

--- a/com.ibm.wala.cast.js.rhino/build.properties
+++ b/com.ibm.wala.cast.js.rhino/build.properties
@@ -2,5 +2,5 @@ source.. = source/
 output.. = bin/
 bin.includes = META-INF/,\
                .,\
-               lib/rhino-1.7R4.jar
-jars.extra.classpath = lib/rhino-1.7R4.jar
+               lib/rhino-1.7R3.jar
+jars.extra.classpath = lib/rhino-1.7R3.jar

--- a/com.ibm.wala.cast.js.rhino/pom.xml
+++ b/com.ibm.wala.cast.js.rhino/pom.xml
@@ -21,7 +21,7 @@
 							<goal>wget</goal>
 						</goals>
 						<configuration>
-							<url>http://repo1.maven.org/maven2/org/mozilla/rhino/1.7R4/rhino-1.7R4.jar</url>
+							<url>http://repo1.maven.org/maven2/org/mozilla/rhino/1.7R3/rhino-1.7R3.jar</url>
 							<outputDirectory>lib/</outputDirectory>
 						</configuration>
 					</execution>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 		<module>com.ibm.wala.cast.java</module>
 		<!-- excluded since ant uses my JRE instead of JDk and thus can't find 
 			tools.jar -->
-		<!-- module>com.ibm.wala.cast.java.polyglot</module -->
+		<module>com.ibm.wala.cast.java.polyglot</module>
 		<module>com.ibm.wala.cast.js</module>
 		<module>com.ibm.wala.cast.js.rhino</module>
 


### PR DESCRIPTION
1. Fixed polyglot antrun build, at least to work on JDK 1.7 on Mac.
2. Made cast.js.rhino point to Rhino 1.7R3.
